### PR TITLE
removed learn button from the home page as that was pushed to a stretch goal

### DIFF
--- a/lib/pages/home.dart
+++ b/lib/pages/home.dart
@@ -67,19 +67,6 @@ class HomePage extends StatelessWidget
               ),
             ),
 
-            Container
-            (
-              margin: EdgeInsets.only(top: 8),
-              child: ElevatedButton
-              (
-                child: Text("Learn"),
-                style: style,
-                onPressed:()
-                {
-                  // Navigator.of(context).push(MaterialPageRoute(builder: (context)=>FormsPage())); SEND TO EDUCATION PAGE
-                },
-              ),
-            ),
 
             Padding(
               padding: EdgeInsets.all(30.0),


### PR DESCRIPTION
During the last meeting with Garry and Keisha we decided that the Learn tool/education material was not particularly important. Because it was pushed to a stretch goal I have removed its button from the home page