### PR TITLE
Vulnerability Form TextFields accept only numbers as input

### DIFF
--- a/lib/pages/vulnerability_detail.dart
+++ b/lib/pages/vulnerability_detail.dart
@@ -781,15 +781,21 @@ class VulnerabilityDetailPage extends StatelessWidget {
                     flex: 1,
                   ),
                   Expanded(
-                    child: TextField(controller: nheHighController),
+                    child: TextField(
+                        controller: nheHighController,
+                        enabled: false),
                     flex: 1,
                   ),
                   Expanded(
-                    child: TextField(controller: nheMedController),
+                    child: TextField(
+                        controller: nheMedController,
+                        enabled: false),
                     flex: 1,
                   ),
                   Expanded(
-                    child: TextField(controller: nheLowController),
+                    child: TextField(
+                        controller: nheLowController,
+                        enabled: false),
                     flex: 1,
                   ),
                 ],

--- a/lib/pages/vulnerability_detail.dart
+++ b/lib/pages/vulnerability_detail.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:makepdfs/models/vulnerableT.dart';
 import 'package:makepdfs/pages/pdfexport/pdfpreview_vulnerable.dart';
 
@@ -536,19 +537,28 @@ class VulnerabilityDetailPage extends StatelessWidget {
                     child: TextField(
                         controller: popHighController,
                         // Keyboard type set to numbers only
-                        keyboardType: TextInputType.number),
+                        keyboardType: TextInputType.number,
+                        inputFormatters: [
+                          FilteringTextInputFormatter.allow(RegExp('[0-9]'))
+                        ]),
                     flex: 1,
                   ),
                   Expanded(
                     child: TextField(
                         controller: popMedController,
-                        keyboardType: TextInputType.number),
+                        keyboardType: TextInputType.number,
+                        inputFormatters: [
+                          FilteringTextInputFormatter.allow(RegExp('[0-9]'))
+                        ]),
                     flex: 1,
                   ),
                   Expanded(
                     child: TextField(
                         controller: popLowController,
-                        keyboardType: TextInputType.number),
+                        keyboardType: TextInputType.number,
+                        inputFormatters: [
+                          FilteringTextInputFormatter.allow(RegExp('[0-9]'))
+                        ]),
                     flex: 1,
                   ),
                 ],
@@ -563,19 +573,28 @@ class VulnerabilityDetailPage extends StatelessWidget {
                   Expanded(
                     child: TextField(
                         controller: elderHighController,
-                        keyboardType: TextInputType.number),
+                        keyboardType: TextInputType.number,
+                        inputFormatters: [
+                          FilteringTextInputFormatter.allow(RegExp('[0-9]'))
+                        ]),
                     flex: 1,
                   ),
                   Expanded(
                     child: TextField(
                         controller: elderMedController,
-                        keyboardType: TextInputType.number),
+                        keyboardType: TextInputType.number,
+                        inputFormatters: [
+                          FilteringTextInputFormatter.allow(RegExp('[0-9]'))
+                        ]),
                     flex: 1,
                   ),
                   Expanded(
                     child: TextField(
                         controller: elderLowController,
-                        keyboardType: TextInputType.number),
+                        keyboardType: TextInputType.number,
+                        inputFormatters: [
+                          FilteringTextInputFormatter.allow(RegExp('[0-9]'))
+                        ]),
                     flex: 1,
                   ),
                 ],
@@ -589,19 +608,28 @@ class VulnerabilityDetailPage extends StatelessWidget {
                   Expanded(
                     child: TextField(
                         controller: childHighController,
-                        keyboardType: TextInputType.number),
+                        keyboardType: TextInputType.number,
+                        inputFormatters: [
+                          FilteringTextInputFormatter.allow(RegExp('[0-9]'))
+                        ]),
                     flex: 1,
                   ),
                   Expanded(
                     child: TextField(
                         controller: childMedController,
-                        keyboardType: TextInputType.number),
+                        keyboardType: TextInputType.number,
+                        inputFormatters: [
+                          FilteringTextInputFormatter.allow(RegExp('[0-9]'))
+                        ]),
                     flex: 1,
                   ),
                   Expanded(
                     child: TextField(
                         controller: childLowController,
-                        keyboardType: TextInputType.number),
+                        keyboardType: TextInputType.number,
+                        inputFormatters: [
+                          FilteringTextInputFormatter.allow(RegExp('[0-9]'))
+                        ]),
                     flex: 1,
                   ),
                 ],
@@ -615,19 +643,28 @@ class VulnerabilityDetailPage extends StatelessWidget {
                   Expanded(
                     child: TextField(
                         controller: hsEdHighController,
-                        keyboardType: TextInputType.number),
+                        keyboardType: TextInputType.number,
+                        inputFormatters: [
+                          FilteringTextInputFormatter.allow(RegExp('[0-9]'))
+                        ]),
                     flex: 1,
                   ),
                   Expanded(
                     child: TextField(
                         controller: hsEdMedController,
-                        keyboardType: TextInputType.number),
+                        keyboardType: TextInputType.number,
+                        inputFormatters: [
+                          FilteringTextInputFormatter.allow(RegExp('[0-9]'))
+                        ]),
                     flex: 1,
                   ),
                   Expanded(
                     child: TextField(
                         controller: hsEdLowController,
-                        keyboardType: TextInputType.number),
+                        keyboardType: TextInputType.number,
+                        inputFormatters: [
+                          FilteringTextInputFormatter.allow(RegExp('[0-9]'))
+                        ]),
                     flex: 1,
                   ),
                 ],
@@ -641,19 +678,28 @@ class VulnerabilityDetailPage extends StatelessWidget {
                   Expanded(
                     child: TextField(
                         controller: linIsoHighController,
-                        keyboardType: TextInputType.number),
+                        keyboardType: TextInputType.number,
+                        inputFormatters: [
+                          FilteringTextInputFormatter.allow(RegExp('[0-9]'))
+                        ]),
                     flex: 1,
                   ),
                   Expanded(
                     child: TextField(
                         controller: linIsoMedController,
-                        keyboardType: TextInputType.number),
+                        keyboardType: TextInputType.number,
+                        inputFormatters: [
+                          FilteringTextInputFormatter.allow(RegExp('[0-9]'))
+                        ]),
                     flex: 1,
                   ),
                   Expanded(
                     child: TextField(
                         controller: linIsoLowController,
-                        keyboardType: TextInputType.number),
+                        keyboardType: TextInputType.number,
+                        inputFormatters: [
+                          FilteringTextInputFormatter.allow(RegExp('[0-9]'))
+                        ]),
                     flex: 1,
                   ),
                 ],
@@ -667,19 +713,28 @@ class VulnerabilityDetailPage extends StatelessWidget {
                   Expanded(
                     child: TextField(
                         controller: pocHighController,
-                        keyboardType: TextInputType.number),
+                        keyboardType: TextInputType.number,
+                        inputFormatters: [
+                          FilteringTextInputFormatter.allow(RegExp('[0-9]'))
+                        ]),
                     flex: 1,
                   ),
                   Expanded(
                     child: TextField(
                         controller: pocMedController,
-                        keyboardType: TextInputType.number),
+                        keyboardType: TextInputType.number,
+                        inputFormatters: [
+                          FilteringTextInputFormatter.allow(RegExp('[0-9]'))
+                        ]),
                     flex: 1,
                   ),
                   Expanded(
                     child: TextField(
                         controller: pocLowController,
-                        keyboardType: TextInputType.number),
+                        keyboardType: TextInputType.number,
+                        inputFormatters: [
+                          FilteringTextInputFormatter.allow(RegExp('[0-9]'))
+                        ]),
                     flex: 1,
                   ),
                 ],
@@ -693,19 +748,28 @@ class VulnerabilityDetailPage extends StatelessWidget {
                   Expanded(
                     child: TextField(
                         controller: lincHighController,
-                        keyboardType: TextInputType.number),
+                        keyboardType: TextInputType.number,
+                        inputFormatters: [
+                          FilteringTextInputFormatter.allow(RegExp('[0-9]'))
+                        ]),
                     flex: 1,
                   ),
                   Expanded(
                     child: TextField(
                         controller: lincMedController,
-                        keyboardType: TextInputType.number),
+                        keyboardType: TextInputType.number,
+                        inputFormatters: [
+                          FilteringTextInputFormatter.allow(RegExp('[0-9]'))
+                        ]),
                     flex: 1,
                   ),
                   Expanded(
                     child: TextField(
                         controller: lincLowController,
-                        keyboardType: TextInputType.number),
+                        keyboardType: TextInputType.number,
+                        inputFormatters: [
+                          FilteringTextInputFormatter.allow(RegExp('[0-9]'))
+                        ]),
                     flex: 1,
                   ),
                 ],
@@ -739,19 +803,28 @@ class VulnerabilityDetailPage extends StatelessWidget {
                   Expanded(
                     child: TextField(
                         controller: housingHighController,
-                        keyboardType: TextInputType.number),
+                        keyboardType: TextInputType.number,
+                        inputFormatters: [
+                          FilteringTextInputFormatter.allow(RegExp('[0-9]'))
+                        ]),
                     flex: 1,
                   ),
                   Expanded(
                     child: TextField(
                         controller: housingMedController,
-                        keyboardType: TextInputType.number),
+                        keyboardType: TextInputType.number,
+                        inputFormatters: [
+                          FilteringTextInputFormatter.allow(RegExp('[0-9]'))
+                        ]),
                     flex: 1,
                   ),
                   Expanded(
                     child: TextField(
                         controller: housingLowController,
-                        keyboardType: TextInputType.number),
+                        keyboardType: TextInputType.number,
+                        inputFormatters: [
+                          FilteringTextInputFormatter.allow(RegExp('[0-9]'))
+                        ]),
                     flex: 1,
                   ),
                 ],
@@ -765,19 +838,28 @@ class VulnerabilityDetailPage extends StatelessWidget {
                   Expanded(
                     child: TextField(
                         controller: schoolsHighController,
-                        keyboardType: TextInputType.number),
+                        keyboardType: TextInputType.number,
+                        inputFormatters: [
+                          FilteringTextInputFormatter.allow(RegExp('[0-9]'))
+                        ]),
                     flex: 1,
                   ),
                   Expanded(
                     child: TextField(
                         controller: schoolsMedController,
-                        keyboardType: TextInputType.number),
+                        keyboardType: TextInputType.number,
+                        inputFormatters: [
+                          FilteringTextInputFormatter.allow(RegExp('[0-9]'))
+                        ]),
                     flex: 1,
                   ),
                   Expanded(
                     child: TextField(
                         controller: schoolsLowController,
-                        keyboardType: TextInputType.number),
+                        keyboardType: TextInputType.number,
+                        inputFormatters: [
+                          FilteringTextInputFormatter.allow(RegExp('[0-9]'))
+                        ]),
                     flex: 1,
                   ),
                 ],
@@ -791,19 +873,28 @@ class VulnerabilityDetailPage extends StatelessWidget {
                   Expanded(
                     child: TextField(
                         controller: hospHighController,
-                        keyboardType: TextInputType.number),
+                        keyboardType: TextInputType.number,
+                        inputFormatters: [
+                          FilteringTextInputFormatter.allow(RegExp('[0-9]'))
+                        ]),
                     flex: 1,
                   ),
                   Expanded(
                     child: TextField(
                         controller: hospMedController,
-                        keyboardType: TextInputType.number),
+                        keyboardType: TextInputType.number,
+                        inputFormatters: [
+                          FilteringTextInputFormatter.allow(RegExp('[0-9]'))
+                        ]),
                     flex: 1,
                   ),
                   Expanded(
                     child: TextField(
                         controller: hospLowController,
-                        keyboardType: TextInputType.number),
+                        keyboardType: TextInputType.number,
+                        inputFormatters: [
+                          FilteringTextInputFormatter.allow(RegExp('[0-9]'))
+                        ]),
                     flex: 1,
                   ),
                 ],
@@ -816,17 +907,26 @@ class VulnerabilityDetailPage extends StatelessWidget {
                   ),
                   Expanded(
                     child: TextField(controller: wasteHighController,
-                        keyboardType: TextInputType.number),
+                        keyboardType: TextInputType.number,
+                        inputFormatters: [
+                          FilteringTextInputFormatter.allow(RegExp('[0-9]'))
+                        ]),
                     flex: 1,
                   ),
                   Expanded(
                     child: TextField(controller: wasteMedController,
-                        keyboardType: TextInputType.number),
+                        keyboardType: TextInputType.number,
+                        inputFormatters: [
+                          FilteringTextInputFormatter.allow(RegExp('[0-9]'))
+                        ]),
                     flex: 1,
                   ),
                   Expanded(
                     child: TextField(controller: wasteLowController,
-                        keyboardType: TextInputType.number),
+                        keyboardType: TextInputType.number,
+                        inputFormatters: [
+                          FilteringTextInputFormatter.allow(RegExp('[0-9]'))
+                        ]),
                     flex: 1,
                   ),
                 ],
@@ -862,17 +962,26 @@ class VulnerabilityDetailPage extends StatelessWidget {
                   ),
                   Expanded(
                     child: TextField(controller: waterHighController,
-                        keyboardType: TextInputType.number),
+                        keyboardType: TextInputType.number,
+                        inputFormatters: [
+                          FilteringTextInputFormatter.allow(RegExp('[0-9]'))
+                        ]),
                     flex: 1,
                   ),
                   Expanded(
                     child: TextField(controller: waterMedController,
-                        keyboardType: TextInputType.number),
+                        keyboardType: TextInputType.number,
+                        inputFormatters: [
+                          FilteringTextInputFormatter.allow(RegExp('[0-9]'))
+                        ]),
                     flex: 1,
                   ),
                   Expanded(
                     child: TextField(controller: waterLowController,
-                        keyboardType: TextInputType.number),
+                        keyboardType: TextInputType.number,
+                        inputFormatters: [
+                          FilteringTextInputFormatter.allow(RegExp('[0-9]'))
+                        ]),
                     flex: 1,
                   ),
                 ],
@@ -885,17 +994,26 @@ class VulnerabilityDetailPage extends StatelessWidget {
                   ),
                   Expanded(
                     child: TextField(controller: wasteWaterHighController,
-                        keyboardType: TextInputType.number),
+                        keyboardType: TextInputType.number,
+                        inputFormatters: [
+                          FilteringTextInputFormatter.allow(RegExp('[0-9]'))
+                        ]),
                     flex: 1,
                   ),
                   Expanded(
                     child: TextField(controller: wasteWaterMedController,
-                        keyboardType: TextInputType.number),
+                        keyboardType: TextInputType.number,
+                        inputFormatters: [
+                          FilteringTextInputFormatter.allow(RegExp('[0-9]'))
+                        ]),
                     flex: 1,
                   ),
                   Expanded(
                     child: TextField(controller: wasteWaterLowController,
-                        keyboardType: TextInputType.number),
+                        keyboardType: TextInputType.number,
+                        inputFormatters: [
+                          FilteringTextInputFormatter.allow(RegExp('[0-9]'))
+                        ]),
                     flex: 1,
                   ),
                 ],
@@ -903,22 +1021,31 @@ class VulnerabilityDetailPage extends StatelessWidget {
               TableRow(
                 children: [
                   Expanded(
-                    child: PaddedText("Essential bussinesses"),
+                    child: PaddedText("Essential businesses"),
                     flex: 1,
                   ),
                   Expanded(
                     child: TextField(controller: essenHighController,
-                        keyboardType: TextInputType.number),
+                        keyboardType: TextInputType.number,
+                        inputFormatters: [
+                          FilteringTextInputFormatter.allow(RegExp('[0-9]'))
+                        ]),
                     flex: 1,
                   ),
                   Expanded(
                     child: TextField(controller: essenMedController,
-                        keyboardType: TextInputType.number),
+                        keyboardType: TextInputType.number,
+                        inputFormatters: [
+                          FilteringTextInputFormatter.allow(RegExp('[0-9]'))
+                        ]),
                     flex: 1,
                   ),
                   Expanded(
                     child: TextField(controller: essenLowController,
-                        keyboardType: TextInputType.number),
+                        keyboardType: TextInputType.number,
+                        inputFormatters: [
+                          FilteringTextInputFormatter.allow(RegExp('[0-9]'))
+                        ]),
                     flex: 1,
                   ),
                 ],


### PR DESCRIPTION
Formatted the text field to deny keyboard inputs that aren't numbers, in case someone else is using another device that will allow them to type in other characters, like with a tablet (that has its own keyboard) or laptop.